### PR TITLE
Unattended upgrades: Add disabled entry for site=rspamd.com

### DIFF
--- a/debian-enable-unattended-upgrades.sh
+++ b/debian-enable-unattended-upgrades.sh
@@ -48,7 +48,7 @@ CUSTOM_CONFIG_FILE=/etc/apt/apt.conf.d/50unattended-upgrades-custom
 
 # Community repositories to enable upgrading packages from.
 COMMUNITY_REPOSITORIES_ENABLED="packages.sury.org deb.nodesource.com dl.yarnpkg.com download.docker.com packages.icinga.com packages.icinga.org download.proxmox.com enterprise.proxmox.com"
-COMMUNITY_REPOSITORIES_DISABLED="packages.grafana.com repo.mosquitto.org repos.influxdata.com repo.mongodb.org packages.gitlab.com download.jitsi.org packages.x2go.org"
+COMMUNITY_REPOSITORIES_DISABLED="packages.grafana.com repo.mosquitto.org repos.influxdata.com repo.mongodb.org packages.gitlab.com download.jitsi.org packages.x2go.org rspamd.com"
 
 
 # ---------------


### PR DESCRIPTION
It looks like we missed to add the `rspamd.com` package repository. However, I am hesitant to add it to the "active" list.